### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,15 @@
         "ybiq": "^16.1.0"
       }
     },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
@@ -660,13 +669,13 @@
       "dev": true
     },
     "node_modules/@commitlint/cli": {
-      "version": "17.6.5",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.6.5.tgz",
-      "integrity": "sha512-3PQrWr/uo6lzF5k7n5QuosCYnzaxP9qGBp3jhWP0Vmsa7XA6wrl9ccPqfQyXpSbQE3zBROVO3TDqgPKe4tfmLQ==",
+      "version": "17.6.6",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.6.6.tgz",
+      "integrity": "sha512-sTKpr2i/Fjs9OmhU+beBxjPavpnLSqZaO6CzwKVq2Tc4UYVTMFgpKOslDhUBVlfAUBfjVO8ParxC/MXkIOevEA==",
       "dev": true,
       "dependencies": {
         "@commitlint/format": "^17.4.4",
-        "@commitlint/lint": "^17.6.5",
+        "@commitlint/lint": "^17.6.6",
         "@commitlint/load": "^17.5.0",
         "@commitlint/read": "^17.5.1",
         "@commitlint/types": "^17.4.4",
@@ -748,25 +757,25 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "17.6.5",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.6.5.tgz",
-      "integrity": "sha512-CQvAPt9gX7cuUbMrIaIMKczfWJqqr6m8IlJs0F2zYwyyMTQ87QMHIj5jJ5HhOaOkaj6dvTMVGx8Dd1I4xgUuoQ==",
+      "version": "17.6.6",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.6.6.tgz",
+      "integrity": "sha512-4Fw875faAKO+2nILC04yW/2Vy/wlV3BOYCSQ4CEFzriPEprc1Td2LILmqmft6PDEK5Sr14dT9tEzeaZj0V56Gg==",
       "dev": true,
       "dependencies": {
         "@commitlint/types": "^17.4.4",
-        "semver": "7.5.0"
+        "semver": "7.5.2"
       },
       "engines": {
         "node": ">=v14"
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "17.6.5",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.5.tgz",
-      "integrity": "sha512-BSJMwkE4LWXrOsiP9KoHG+/heSDfvOL/Nd16+ojTS/DX8HZr8dNl8l3TfVr/d/9maWD8fSegRGtBtsyGuugFrw==",
+      "version": "17.6.6",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.6.tgz",
+      "integrity": "sha512-5bN+dnHcRLkTvwCHYMS7Xpbr+9uNi0Kq5NR3v4+oPNx6pYXt8ACuw9luhM/yMgHYwW0ajIR20wkPAFkZLEMGmg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/is-ignored": "^17.6.5",
+        "@commitlint/is-ignored": "^17.6.6",
         "@commitlint/parse": "^17.6.5",
         "@commitlint/rules": "^17.6.5",
         "@commitlint/types": "^17.4.4"
@@ -8881,17 +8890,17 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
       "dev": true,
       "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -10867,9 +10876,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -12396,15 +12405,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -12645,6 +12645,12 @@
     }
   },
   "dependencies": {
+    "@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true
+    },
     "@ampproject/remapping": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
@@ -13135,13 +13141,13 @@
       "dev": true
     },
     "@commitlint/cli": {
-      "version": "17.6.5",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.6.5.tgz",
-      "integrity": "sha512-3PQrWr/uo6lzF5k7n5QuosCYnzaxP9qGBp3jhWP0Vmsa7XA6wrl9ccPqfQyXpSbQE3zBROVO3TDqgPKe4tfmLQ==",
+      "version": "17.6.6",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.6.6.tgz",
+      "integrity": "sha512-sTKpr2i/Fjs9OmhU+beBxjPavpnLSqZaO6CzwKVq2Tc4UYVTMFgpKOslDhUBVlfAUBfjVO8ParxC/MXkIOevEA==",
       "dev": true,
       "requires": {
         "@commitlint/format": "^17.4.4",
-        "@commitlint/lint": "^17.6.5",
+        "@commitlint/lint": "^17.6.6",
         "@commitlint/load": "^17.5.0",
         "@commitlint/read": "^17.5.1",
         "@commitlint/types": "^17.4.4",
@@ -13202,22 +13208,22 @@
       }
     },
     "@commitlint/is-ignored": {
-      "version": "17.6.5",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.6.5.tgz",
-      "integrity": "sha512-CQvAPt9gX7cuUbMrIaIMKczfWJqqr6m8IlJs0F2zYwyyMTQ87QMHIj5jJ5HhOaOkaj6dvTMVGx8Dd1I4xgUuoQ==",
+      "version": "17.6.6",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.6.6.tgz",
+      "integrity": "sha512-4Fw875faAKO+2nILC04yW/2Vy/wlV3BOYCSQ4CEFzriPEprc1Td2LILmqmft6PDEK5Sr14dT9tEzeaZj0V56Gg==",
       "dev": true,
       "requires": {
         "@commitlint/types": "^17.4.4",
-        "semver": "7.5.0"
+        "semver": "7.5.2"
       }
     },
     "@commitlint/lint": {
-      "version": "17.6.5",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.5.tgz",
-      "integrity": "sha512-BSJMwkE4LWXrOsiP9KoHG+/heSDfvOL/Nd16+ojTS/DX8HZr8dNl8l3TfVr/d/9maWD8fSegRGtBtsyGuugFrw==",
+      "version": "17.6.6",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.6.tgz",
+      "integrity": "sha512-5bN+dnHcRLkTvwCHYMS7Xpbr+9uNi0Kq5NR3v4+oPNx6pYXt8ACuw9luhM/yMgHYwW0ajIR20wkPAFkZLEMGmg==",
       "dev": true,
       "requires": {
-        "@commitlint/is-ignored": "^17.6.5",
+        "@commitlint/is-ignored": "^17.6.6",
         "@commitlint/parse": "^17.6.5",
         "@commitlint/rules": "^17.6.5",
         "@commitlint/types": "^17.4.4"
@@ -19192,17 +19198,17 @@
       }
     },
     "optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
       "dev": true,
       "requires": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       }
     },
     "p-limit": {
@@ -20661,9 +20667,9 @@
       }
     },
     "semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -21805,12 +21811,6 @@
         "has-tostringtag": "^1.0.0",
         "is-typed-array": "^1.1.10"
       }
-    },
-    "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",


### PR DESCRIPTION
This pull request fixes the vulnerable packages via npm [9.7.2](https://github.com/npm/cli/releases/tag/v9.7.2).

<details open>
<summary><strong>Updated (5)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [@commitlint/cli](https://www.npmjs.com/package/@commitlint/cli/v/17.6.6) | `17.6.5` → `17.6.6` | [github](https://github.com/conventional-changelog/commitlint) | - |
| [@commitlint/is-ignored](https://www.npmjs.com/package/@commitlint/is-ignored/v/17.6.6) | `17.6.5` → `17.6.6` | [github](https://github.com/conventional-changelog/commitlint) | - |
| [@commitlint/lint](https://www.npmjs.com/package/@commitlint/lint/v/17.6.6) | `17.6.5` → `17.6.6` | [github](https://github.com/conventional-changelog/commitlint) | - |
| [optionator](https://www.npmjs.com/package/optionator/v/0.9.3) | `0.9.1` → `0.9.3` | [github](https://github.com/gkz/optionator) | - |
| [semver](https://www.npmjs.com/package/semver/v/7.5.2) | `7.5.0` → `7.5.2` | [github](https://github.com/npm/node-semver) | **[Moderate]** semver vulnerable to Regular Expression Denial of Service ([ref](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw)) |

</details>

<details open>
<summary><strong>Added (1)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [@aashutoshrathi/word-wrap](https://www.npmjs.com/package/@aashutoshrathi/word-wrap/v/1.2.6) | `1.2.6` | [github](https://github.com/aashutoshrathi/word-wrap) | - |

</details>

<details open>
<summary><strong>Removed (1)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [word-wrap](https://www.npmjs.com/package/word-wrap/v/1.2.3) | `1.2.3` | [github](https://github.com/jonschlinkert/word-wrap) | - |

</details>

***

Created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action)