### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1493,9 +1493,9 @@
       }
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "5.2.60",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.60.tgz",
-      "integrity": "sha512-HbULfvqZLvcjqjvXjQKpFPts6pS4awUa++0j8UukBPwDMLQYvDDbZnl/CQTjFv3cGGaoJS5A1aHLgxP9d/4SMw==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.3.14.tgz",
+      "integrity": "sha512-Y9XQrphVcE6u9xMm+gIqN86opbU/5s2W1pdPyKRyFV5B7+2jWM2gLI5JpfhZncaoDKvhy6FYwK04aCz5UM/bTQ==",
       "dev": true
     },
     "node_modules/@nicolo-ribaudo/semver-v6": {
@@ -2769,9 +2769,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.9",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+      "version": "4.21.10",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
+      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
       "dev": true,
       "funding": [
         {
@@ -2788,9 +2788,9 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001503",
-        "electron-to-chromium": "^1.4.431",
-        "node-releases": "^2.0.12",
+        "caniuse-lite": "^1.0.30001517",
+        "electron-to-chromium": "^1.4.477",
+        "node-releases": "^2.0.13",
         "update-browserslist-db": "^1.0.11"
       },
       "bin": {
@@ -2864,9 +2864,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001513",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001513.tgz",
-      "integrity": "sha512-pnjGJo7SOOjAGytZZ203Em95MRM8Cr6jhCXNF/FAXTpCTRTECnqQWLpiTRqrFtdYcth8hf4WECUpkezuYsMVww==",
+      "version": "1.0.30001524",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
+      "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==",
       "dev": true,
       "funding": [
         {
@@ -3903,9 +3903,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.453",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.453.tgz",
-      "integrity": "sha512-BU8UtQz6CB3T7RIGhId4BjmjJVXQDujb0+amGL8jpcluFJr6lwspBOvkUbnttfpZCm4zFMHmjrX1QrdPWBBMjQ==",
+      "version": "1.4.505",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.505.tgz",
+      "integrity": "sha512-0A50eL5BCCKdxig2SsCXhpuztnB9PfUgRMojj5tMvt8O54lbwz3t6wNgnpiTRosw5QjlJB7ixhVyeg8daLQwSQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4191,19 +4191,18 @@
       }
     },
     "node_modules/eslint-plugin-compat": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.1.4.tgz",
-      "integrity": "sha512-RxySWBmzfIROLFKgeJBJue2BU/6vM2KJWXWAUq+oW4QtrsZXRxbjgxmO1OfF3sHcRuuIenTS/wgo3GyUWZF24w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.2.0.tgz",
+      "integrity": "sha512-RDKSYD0maWy5r7zb5cWQS+uSPc26mgOzdORJ8hxILmWM7S/Ncwky7BcAtXVY5iRbKjBdHsWU8Yg7hfoZjtkv7w==",
       "dev": true,
       "dependencies": {
-        "@mdn/browser-compat-data": "^5.2.47",
-        "@tsconfig/node14": "^1.0.3",
+        "@mdn/browser-compat-data": "^5.3.13",
         "ast-metadata-inferer": "^0.8.0",
-        "browserslist": "^4.21.5",
-        "caniuse-lite": "^1.0.30001473",
+        "browserslist": "^4.21.10",
+        "caniuse-lite": "^1.0.30001524",
         "find-up": "^5.0.0",
-        "lodash.memoize": "4.1.2",
-        "semver": "7.3.8"
+        "lodash.memoize": "^4.1.2",
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": ">=14.x"
@@ -4213,9 +4212,9 @@
       }
     },
     "node_modules/eslint-plugin-compat/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -8512,9 +8511,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
     },
     "node_modules/nopt": {
@@ -13801,9 +13800,9 @@
       }
     },
     "@mdn/browser-compat-data": {
-      "version": "5.2.60",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.60.tgz",
-      "integrity": "sha512-HbULfvqZLvcjqjvXjQKpFPts6pS4awUa++0j8UukBPwDMLQYvDDbZnl/CQTjFv3cGGaoJS5A1aHLgxP9d/4SMw==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.3.14.tgz",
+      "integrity": "sha512-Y9XQrphVcE6u9xMm+gIqN86opbU/5s2W1pdPyKRyFV5B7+2jWM2gLI5JpfhZncaoDKvhy6FYwK04aCz5UM/bTQ==",
       "dev": true
     },
     "@nicolo-ribaudo/semver-v6": {
@@ -14776,14 +14775,14 @@
       }
     },
     "browserslist": {
-      "version": "4.21.9",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+      "version": "4.21.10",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
+      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001503",
-        "electron-to-chromium": "^1.4.431",
-        "node-releases": "^2.0.12",
+        "caniuse-lite": "^1.0.30001517",
+        "electron-to-chromium": "^1.4.477",
+        "node-releases": "^2.0.13",
         "update-browserslist-db": "^1.0.11"
       }
     },
@@ -14836,9 +14835,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001513",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001513.tgz",
-      "integrity": "sha512-pnjGJo7SOOjAGytZZ203Em95MRM8Cr6jhCXNF/FAXTpCTRTECnqQWLpiTRqrFtdYcth8hf4WECUpkezuYsMVww==",
+      "version": "1.0.30001524",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
+      "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==",
       "dev": true
     },
     "ccount": {
@@ -15614,9 +15613,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.453",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.453.tgz",
-      "integrity": "sha512-BU8UtQz6CB3T7RIGhId4BjmjJVXQDujb0+amGL8jpcluFJr6lwspBOvkUbnttfpZCm4zFMHmjrX1QrdPWBBMjQ==",
+      "version": "1.4.505",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.505.tgz",
+      "integrity": "sha512-0A50eL5BCCKdxig2SsCXhpuztnB9PfUgRMojj5tMvt8O54lbwz3t6wNgnpiTRosw5QjlJB7ixhVyeg8daLQwSQ==",
       "dev": true
     },
     "emittery": {
@@ -15864,25 +15863,24 @@
       }
     },
     "eslint-plugin-compat": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.1.4.tgz",
-      "integrity": "sha512-RxySWBmzfIROLFKgeJBJue2BU/6vM2KJWXWAUq+oW4QtrsZXRxbjgxmO1OfF3sHcRuuIenTS/wgo3GyUWZF24w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.2.0.tgz",
+      "integrity": "sha512-RDKSYD0maWy5r7zb5cWQS+uSPc26mgOzdORJ8hxILmWM7S/Ncwky7BcAtXVY5iRbKjBdHsWU8Yg7hfoZjtkv7w==",
       "dev": true,
       "requires": {
-        "@mdn/browser-compat-data": "^5.2.47",
-        "@tsconfig/node14": "^1.0.3",
+        "@mdn/browser-compat-data": "^5.3.13",
         "ast-metadata-inferer": "^0.8.0",
-        "browserslist": "^4.21.5",
-        "caniuse-lite": "^1.0.30001473",
+        "browserslist": "^4.21.10",
+        "caniuse-lite": "^1.0.30001524",
         "find-up": "^5.0.0",
-        "lodash.memoize": "4.1.2",
-        "semver": "7.3.8"
+        "lodash.memoize": "^4.1.2",
+        "semver": "^7.5.4"
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -18929,9 +18927,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
     },
     "nopt": {


### PR DESCRIPTION
This pull request fixes the vulnerable packages via npm [9.8.1](https://github.com/npm/cli/releases/tag/v9.8.1).

<details open>
<summary><strong>Updated (7)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [@mdn/browser-compat-data](https://www.npmjs.com/package/@mdn/browser-compat-data/v/5.3.14) | `5.2.60` → `5.3.14` | [github](https://github.com/mdn/browser-compat-data) | - |
| [browserslist](https://www.npmjs.com/package/browserslist/v/4.21.10) | `4.21.9` → `4.21.10` | [github](https://github.com/browserslist/browserslist) | - |
| [caniuse-lite](https://www.npmjs.com/package/caniuse-lite/v/1.0.30001524) | `1.0.30001513` → `1.0.30001524` | [github](https://github.com/browserslist/caniuse-lite) | - |
| [electron-to-chromium](https://www.npmjs.com/package/electron-to-chromium/v/1.4.505) | `1.4.453` → `1.4.505` | [github](https://github.com/kilian/electron-to-chromium) | - |
| [eslint-plugin-compat](https://www.npmjs.com/package/eslint-plugin-compat/v/4.2.0) | `4.1.4` → `4.2.0` | [github](https://github.com/amilajack/eslint-plugin-compat) | - |
| [node-releases](https://www.npmjs.com/package/node-releases/v/2.0.13) | `2.0.12` → `2.0.13` | [github](https://github.com/chicoxyzzy/node-releases) | - |
| [semver](https://www.npmjs.com/package/semver/v/7.5.4) (`eslint-plugin-compat/node_modules/semver`) | `7.3.8` → `7.5.4` | [github](https://github.com/npm/node-semver) | **[Moderate]** semver vulnerable to Regular Expression Denial of Service ([ref](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw)) |

</details>

***

Created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action)