### PR TITLE
chore: fix commitlint failure due to `header-max-length`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: monthly
     versioning-strategy: increase
     groups:
-      development-dependencies:
+      dev-deps:
         dependency-type: "development"
         exclude-patterns:
           - "remark"

--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
         1,
         "always",
         300
+      ],
+      "header-max-length": [
+        1,
+        "always",
+        150
       ]
     }
   },


### PR DESCRIPTION
Also, this shortens a Dependabot group name for development dependencies.
