### PR TITLE
chore: explicitly set `noEmit` to true in `tsconfig.json`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@tsconfig/strictest",
+  "compilerOptions": {
+    "noEmit": true
+  },
   "exclude": ["**/*.test.*", "coverage/**"]
 }


### PR DESCRIPTION
The explicitly set `noEmit` prevents warnings on editors like VS Code.